### PR TITLE
fix/improve OpenApi documentation

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.loggingmanager.deployment;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.OASFactory;
@@ -10,14 +8,8 @@ import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
-import org.eclipse.microprofile.openapi.models.Paths;
-import org.eclipse.microprofile.openapi.models.media.Content;
-import org.eclipse.microprofile.openapi.models.media.MediaType;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
-import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
-import org.eclipse.microprofile.openapi.models.responses.APIResponse;
-import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 
 import io.quarkus.vertx.http.runtime.logstream.LogController;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
@@ -26,14 +18,12 @@ import io.smallrye.openapi.api.models.media.SchemaImpl;
  * Create OpenAPI entries (if configured)
  */
 public class LoggingManagerOpenAPIFilter implements OASFilter {
+
     private static final String JSON_CONTENT_TYPE = "application/json";
     private static final String FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
-    private static final String REF_LOGGER_NAME = "#/components/schemas/LoggerName";
     private static final String REF_LOGGER_LEVEL = "#/components/schemas/LoggerLevel";
-
-    private static final String REF_LIST_LOGGER_INFO = "#/components/schemas/ListLoggerInfo";
-    private static final String REF_LIST_STRING = "#/components/schemas/ListString";
+    private static final String REF_LOGGER_INFO = "#/components/schemas/LoggerInfo";
 
     private final String basePath;
     private final String tag;
@@ -48,225 +38,96 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
         if (openAPI.getComponents() == null) {
             openAPI.setComponents(OASFactory.createComponents());
         }
-
-        openAPI.getComponents().addSchema("LoggerName", createLoggerName());
-        openAPI.getComponents().addSchema("LoggerLevel", createLoggerLevel());
-        openAPI.getComponents().addSchema("ListLoggerInfo", createListLoggerInfo());
-        openAPI.getComponents().addSchema("LoggerInfo", createLoggerInfo());
-        openAPI.getComponents().addSchema("ListString", createListString());
-
+        openAPI.getComponents()
+                .addSchema("LoggerLevel", createLoggerLevel())
+                .addSchema("LoggerInfo", createLoggerInfo());
         if (openAPI.getPaths() == null) {
             openAPI.setPaths(OASFactory.createPaths());
         }
-        Paths paths = openAPI.getPaths();
-
-        // Loggers
-        paths.addPathItem(basePath, createLoggersPathItem());
-
-        // Levels
-        paths.addPathItem(basePath + "/levels", createLevelsPathItem());
-    }
-
-    private PathItem createLevelsPathItem() {
-        PathItem pathItem = OASFactory.createPathItem();
-        pathItem.setDescription("All available levels ");
-        pathItem.setSummary(
-                "Return all levels that is available");
-        pathItem.setGET(createLevelsOperation());
-        return pathItem;
-    }
-
-    private Operation createLevelsOperation() {
-        Operation operation = OASFactory.createOperation();
-        operation.setDescription("This returns all possible log levels");
-        operation.setOperationId("logging_manager_levels");
-        operation.setTags(Collections.singletonList(tag));
-        operation.setSummary("Get all available levels");
-        operation.setResponses(createLevelsAPIResponses());
-        return operation;
-    }
-
-    private APIResponses createLevelsAPIResponses() {
-        APIResponses responses = OASFactory.createAPIResponses();
-        responses.addAPIResponse("200", createLevelsAPIResponse());
-        return responses;
-    }
-
-    private APIResponse createLevelsAPIResponse() {
-        APIResponse response = OASFactory.createAPIResponse();
-        response.setContent(createLevelsContent());
-        return response;
-    }
-
-    private Content createLevelsContent() {
-        Content content = OASFactory.createContent();
-        content.addMediaType(JSON_CONTENT_TYPE, createLevelsMediaType());
-        return content;
-    }
-
-    private MediaType createLevelsMediaType() {
-        MediaType mediaType = OASFactory.createMediaType();
-        mediaType.setSchema(OASFactory.createSchema().ref(REF_LIST_STRING));
-        return mediaType;
-    }
-
-    private PathItem createLoggersPathItem() {
-        PathItem pathItem = OASFactory.createPathItem();
-        pathItem.setDescription("Logging Manager Loggers");
-        pathItem.setSummary(
-                "Return info on all loggers, or a specific logger");
-        pathItem.setGET(createLoggersOperation());
-        pathItem.setPOST(createLoggerPostOperation());
-        return pathItem;
-    }
-
-    private Operation createLoggerPostOperation() {
-        Operation operation = OASFactory.createOperation();
-        operation.setDescription("Update a log level for a certain logger");
-        operation.setOperationId("logging_manager_update");
-        operation.setTags(Collections.singletonList(tag));
-        operation.setSummary("Update log level");
-        operation.setResponses(createLoggerPostAPIResponses());
-        operation.setRequestBody(createLoggersPostRequestBody());
-        return operation;
-    }
-
-    private RequestBody createLoggersPostRequestBody() {
-        RequestBody requestBody = OASFactory.createRequestBody();
-        requestBody.setContent(createRequestBodyContent());
-        return requestBody;
-    }
-
-    private Content createRequestBodyContent() {
-        Content content = OASFactory.createContent();
-        content.addMediaType(FORM_CONTENT_TYPE, createRequestBodyMediaType());
-
-        return content;
-    }
-
-    private MediaType createRequestBodyMediaType() {
-        MediaType mediaType = OASFactory.createMediaType();
-
-        Schema schema = OASFactory.createSchema();
-        schema.setType(Schema.SchemaType.OBJECT);
-
-        Map<String, Schema> properties = new HashMap<>();
-        properties.put("loggerName", OASFactory.createSchema().ref(REF_LOGGER_NAME));
-        properties.put("loggerLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL));
-        schema.setProperties(properties);
-
-        mediaType.setSchema(schema);
-
-        return mediaType;
-    }
-
-    private APIResponses createLoggerPostAPIResponses() {
-        APIResponses responses = OASFactory.createAPIResponses();
-        APIResponse apiResponse = OASFactory.createAPIResponse();
-        apiResponse.setDescription("Created");
-        responses.addAPIResponse("201", apiResponse);
-        return responses;
-    }
-
-    private Operation createLoggersOperation() {
-        Operation operation = OASFactory.createOperation();
-        operation.setDescription("Get information on all loggers or a specific logger.");
-        operation.setOperationId("logging_manager_get_all");
-        operation.setTags(Collections.singletonList(tag));
-        operation.setSummary("Information on Logger(s)");
-        operation.setResponses(createLoggersAPIResponses());
-        operation.addParameter(createLoggersParameter());
-        return operation;
-    }
-
-    private APIResponses createLoggersAPIResponses() {
-        APIResponses responses = OASFactory.createAPIResponses();
-        responses.addAPIResponse("200", createLoggersAPIResponse());
-        APIResponse notFound = OASFactory.createAPIResponse();
-        notFound.setDescription("Not Found");
-        responses.addAPIResponse("404", notFound);
-        return responses;
-    }
-
-    private APIResponse createLoggersAPIResponse() {
-        APIResponse response = OASFactory.createAPIResponse();
-        response.setContent(createLoggersContent());
-        return response;
-    }
-
-    private Content createLoggersContent() {
-        Content content = OASFactory.createContent();
-        content.addMediaType(JSON_CONTENT_TYPE, createLoggersMediaType());
-        return content;
-    }
-
-    private MediaType createLoggersMediaType() {
-        MediaType mediaType = OASFactory.createMediaType();
-        mediaType.setSchema(OASFactory.createSchema().ref(REF_LIST_LOGGER_INFO));
-        return mediaType;
-    }
-
-    private Parameter createLoggersParameter() {
-        Parameter p = OASFactory.createParameter();
-        p.setName("loggerName");
-        p.setIn(Parameter.In.QUERY);
-        p.setSchema(OASFactory.createSchema().type(Schema.SchemaType.STRING));
-        return p;
-    }
-
-    private Schema createLoggerName() {
-        Schema schema = new SchemaImpl("LoggerName");
-        schema.setType(Schema.SchemaType.STRING);
-        schema.setDescription("The logger name");
-
-        return schema;
+        openAPI.getPaths()
+                .addPathItem(basePath, createLoggersPathItem())
+                .addPathItem(basePath + "/levels", createLevelsPathItem());
     }
 
     private Schema createLoggerLevel() {
-        Schema schema = new SchemaImpl("LoggerLevel");
-        schema.setType(Schema.SchemaType.STRING);
-
-        List<String> loggerLevels = LogController.LEVELS;
-        for (String l : loggerLevels) {
-            schema.addEnumeration(l);
-        }
+        Schema schema = new SchemaImpl("LoggerLevel")
+                .type(Schema.SchemaType.STRING);
+        LogController.LEVELS.forEach(schema::addEnumeration);
         return schema;
     }
 
     private Schema createLoggerInfo() {
-        Schema schema = new SchemaImpl("LoggerInfo");
-        schema.setType(Schema.SchemaType.OBJECT);
-        schema.setProperties(createLoggerInfoProperties());
-        return schema;
+        return new SchemaImpl("LoggerInfo")
+                .type(Schema.SchemaType.OBJECT)
+                .properties(Map.of(
+                        "configuredLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL),
+                        "effectiveLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL),
+                        "name", OASFactory.createSchema().type(Schema.SchemaType.STRING)));
     }
 
-    private Map<String, Schema> createLoggerInfoProperties() {
-        Map<String, Schema> map = new HashMap<>();
-        map.put("configuredLevel", createStringSchema("configuredLevel"));
-        map.put("effectiveLevel", createStringSchema("effectiveLevel"));
-        map.put("name", createStringSchema("name"));
-
-        return map;
+    private PathItem createLoggersPathItem() {
+        return OASFactory.createPathItem()
+                .summary("Return info on all loggers, or a specific logger")
+                .description("Logging Manager Loggers")
+                .GET(createLoggersGetOperation())
+                .POST(createLoggerPostOperation());
     }
 
-    private Schema createStringSchema(String name) {
-        Schema schema = new SchemaImpl(name);
-        schema.setType(Schema.SchemaType.STRING);
-        return schema;
+    private Operation createLoggersGetOperation() {
+        return OASFactory.createOperation()
+                .operationId("logging_manager_get_all")
+                .summary("Information on Logger(s)")
+                .description("Get information on all loggers or a specific logger.")
+                .tags(Collections.singletonList(tag))
+                .addParameter(OASFactory.createParameter()
+                        .name("loggerName").in(Parameter.In.QUERY)
+                        .schema(OASFactory.createSchema().type(Schema.SchemaType.STRING)))
+                .responses(OASFactory.createAPIResponses()
+                        .addAPIResponse("200", OASFactory.createAPIResponse()
+                                .description("Ok")
+                                .content(OASFactory.createContent().addMediaType(
+                                        JSON_CONTENT_TYPE,
+                                        OASFactory.createMediaType().schema(OASFactory.createSchema()
+                                                .type(Schema.SchemaType.ARRAY)
+                                                .items(OASFactory.createSchema().ref(REF_LOGGER_INFO))))))
+                        .addAPIResponse("404", OASFactory.createAPIResponse().description("Not Found")));
     }
 
-    private Schema createListString() {
-        Schema schema = new SchemaImpl("ListString");
-        schema.setType(Schema.SchemaType.ARRAY);
-        schema.setItems(new SchemaImpl().type(Schema.SchemaType.STRING));
-        return schema;
+    private Operation createLoggerPostOperation() {
+        return OASFactory.createOperation()
+                .operationId("logging_manager_update")
+                .summary("Update log level")
+                .description("Update a log level for a certain logger")
+                .tags(Collections.singletonList(tag))
+                .requestBody(OASFactory.createRequestBody()
+                        .content(OASFactory.createContent().addMediaType(
+                                FORM_CONTENT_TYPE,
+                                OASFactory.createMediaType().schema(OASFactory.createSchema()
+                                        .type(Schema.SchemaType.OBJECT)
+                                        .properties(Map.of(
+                                                "loggerName", OASFactory.createSchema(),
+                                                "loggerLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL)))))))
+                .responses(OASFactory.createAPIResponses()
+                        .addAPIResponse("201", OASFactory.createAPIResponse().description("Created")));
     }
 
-    private Schema createListLoggerInfo() {
-        Schema schema = new SchemaImpl("ListLoggerInfo");
-        schema.setType(Schema.SchemaType.ARRAY);
-        schema.setItems(new SchemaImpl().ref(REF_LIST_LOGGER_INFO));
-        return schema;
+    private PathItem createLevelsPathItem() {
+        return OASFactory.createPathItem()
+                .description("All available levels")
+                .summary("Return all levels that is available")
+                .GET(OASFactory.createOperation()
+                        .description("This returns all possible log levels")
+                        .operationId("logging_manager_levels")
+                        .tags(Collections.singletonList(tag))
+                        .summary("Get all available levels")
+                        .responses(OASFactory.createAPIResponses()
+                                .addAPIResponse("200", OASFactory.createAPIResponse()
+                                        .description("Ok")
+                                        .content(OASFactory.createContent().addMediaType(
+                                                JSON_CONTENT_TYPE,
+                                                OASFactory.createMediaType().schema(OASFactory.createSchema()
+                                                        .type(Schema.SchemaType.ARRAY)
+                                                        .items(OASFactory.createSchema().ref(REF_LOGGER_LEVEL))))))));
     }
 
 }


### PR DESCRIPTION
fixed some issues in the openApi:
- added missing response-description
- refactored ListLoggerInfo to List of Objects with correct descriptions
- used ref to LogLevel-Enum instead of string

Generated OpenApi.yaml should now look like this:
Paths-section:
```
/masterdata-svc/q/logging-manager:
    summary: "Return info on all loggers, or a specific logger"
    description: Logging Manager Loggers
    get:
      tags:
      - system info (private)
      summary: Information on Logger(s)
      description: Get information on all loggers or a specific logger.
      operationId: logging_manager_get_all
      parameters:
      - name: loggerName
        in: query
        schema:
          type: string
      responses:
        "200":
          description: Ok
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/LoggerInfo'
        "404":
          description: Not Found
    post:
      tags:
      - system info (private)
      summary: Update log level
      description: Update a log level for a certain logger
      operationId: logging_manager_update
      requestBody:
        content:
          application/x-www-form-urlencoded:
            schema:
              type: object
              properties:
                loggerLevel:
                  $ref: '#/components/schemas/LoggerLevel'
                loggerName: {}
      responses:
        "201":
          description: Created
  /masterdata-svc/q/logging-manager/levels:
    summary: Return all levels that is available
    description: All available levels
    get:
      tags:
      - system info (private)
      summary: Get all available levels
      description: This returns all possible log levels
      operationId: logging_manager_levels
      responses:
        "200":
          description: Ok
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/LoggerLevel'`
```
Schema-section:
```
LoggerLevel:
      enum:
      - "OFF"
      - SEVERE
      - ERROR
      - FATAL
      - WARNING
      - WARN
      - INFO
      - DEBUG
      - TRACE
      - CONFIG
      - FINE
      - FINER
      - FINEST
      - ALL
      type: string

LoggerInfo:
      type: object
      properties:
        configuredLevel:
          $ref: '#/components/schemas/LoggerLevel'
        effectiveLevel:
          $ref: '#/components/schemas/LoggerLevel'
        name:
          type: string
```