### PR TITLE
Bump quarkus.version, quarkiverse-parent, and maven plugin versions

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -12,7 +12,7 @@
     <name>Quarkus - Logging Manager - Deployment</name>
 
     <properties>
-        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <maven.surefire.version>3.0.0-M9</maven.surefire.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse</groupId>
         <artifactId>quarkiverse-parent</artifactId>
-        <version>10</version>
+        <version>12</version>
     </parent>
 
     <groupId>io.quarkiverse.loggingmanager</groupId>
@@ -22,8 +22,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>2.11.2.Final</quarkus.version>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <quarkus.version>2.16.5.Final</quarkus.version>
+        <compiler-plugin.version>3.11.0</compiler-plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Bumps `quarkus.version` from 2.11.2.Final to 2.16.5.Final
Bumps `quarkiverse-parent` from 10 to 12
Bumps `compiler-plugin.version` from 3.8.1 to 3.11.0
Bumps `maven.surefire.version` from 3.0.0-M7 to 3.0.0-M9