### PR TITLE
bump quarkus version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus.version>3.2.0.Final</quarkus.version>
+        <quarkus.version>3.2.2.Final</quarkus.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
     </properties>
 


### PR DESCRIPTION
Bumps `quarkus.version` from 3.2.0.Final to 3.2.2.Final
