### PR TITLE
bump quarkus version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.8.5</quarkus.version>
+        <quarkus.version>3.15.1</quarkus.version>
     </properties>  
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
3.15 is the new LTS version, see [here](https://quarkus.io/blog/quarkus-3-15-1-released/)
@melloware 
@phillip-kruger 