### PR TITLE
OpenAPI Filter force its order to prevent flickering

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-openapi-spi</artifactId>
+            <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
         </dependency>
         
         <dependency>

--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
@@ -15,10 +15,12 @@ import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.tags.Tag;
 
 import io.quarkiverse.loggingmanager.LogController;
+import io.quarkus.smallrye.openapi.OpenApiFilter;
 
 /**
  * Create OpenAPI entries (if configured)
  */
+@OpenApiFilter(value = OpenApiFilter.RunStage.BOTH, priority = 99)
 public class LoggingManagerOpenAPIFilter implements OASFilter {
 
     private static final String JSON_CONTENT_TYPE = "application/json";

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -21,6 +21,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-openapi</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Because this just uses the default priority = 1 and so does the Health API they can flicker back and forth in the generated OpenAPI docs.

cc @phillip-kruger 