### PR TITLE
Use RuntimeValue to pass runtime config to recorder

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerProcessor.java
@@ -12,6 +12,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
@@ -58,7 +59,7 @@ class LoggingManagerProcessor {
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .management()
                     .routeFunction(loggingManagerConfig.basePath(),
-                            recorder.routeConsumer(bodyHandlerBuildItem.getHandler(), runtimeConfig))
+                            recorder.routeConsumer(bodyHandlerBuildItem.getHandler(), new RuntimeValue<>(runtimeConfig)))
                     .displayOnNotFoundPage("LogManager All available loggers")
                     .handler(loggerHandler)
                     .build());

--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerProcessor.java
@@ -12,7 +12,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
-import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.configuration.ConfigurationException;
 import io.quarkus.smallrye.openapi.deployment.spi.AddToOpenAPIDefinitionBuildItem;
 import io.quarkus.vertx.http.deployment.BodyHandlerBuildItem;
@@ -59,7 +58,7 @@ class LoggingManagerProcessor {
             routeProducer.produce(nonApplicationRootPathBuildItem.routeBuilder()
                     .management()
                     .routeFunction(loggingManagerConfig.basePath(),
-                            recorder.routeConsumer(bodyHandlerBuildItem.getHandler(), new RuntimeValue<>(runtimeConfig)))
+                            recorder.routeConsumer(bodyHandlerBuildItem.getHandler()))
                     .displayOnNotFoundPage("LogManager All available loggers")
                     .handler(loggerHandler)
                     .build());

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.20.0</quarkus.version>
+        <quarkus.version>3.20.2</quarkus.version>
     </properties>  
     <dependencyManagement>
         <dependencies>

--- a/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerManagerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerManagerRecorder.java
@@ -2,6 +2,8 @@ package io.quarkiverse.loggingmanager;
 
 import java.util.function.Consumer;
 
+import jakarta.inject.Inject;
+
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
@@ -11,6 +13,13 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class LoggerManagerRecorder {
 
+    private final RuntimeValue<LoggingManagerRuntimeConfig> runtimeConfig;
+
+    @Inject
+    public LoggerManagerRecorder(RuntimeValue<LoggingManagerRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
     public Handler<RoutingContext> loggerHandler() {
         return new LoggerHandler();
     }
@@ -19,8 +28,7 @@ public class LoggerManagerRecorder {
         return new LevelHandler();
     }
 
-    public Consumer<Route> routeConsumer(Handler<RoutingContext> bodyHandler,
-            RuntimeValue<LoggingManagerRuntimeConfig> runtimeConfig) {
+    public Consumer<Route> routeConsumer(Handler<RoutingContext> bodyHandler) {
         if (runtimeConfig.getValue().enable()) {
             return route -> route.handler(bodyHandler);
         } else {

--- a/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerManagerRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerManagerRecorder.java
@@ -2,6 +2,7 @@ package io.quarkiverse.loggingmanager;
 
 import java.util.function.Consumer;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.Route;
@@ -18,8 +19,9 @@ public class LoggerManagerRecorder {
         return new LevelHandler();
     }
 
-    public Consumer<Route> routeConsumer(Handler<RoutingContext> bodyHandler, LoggingManagerRuntimeConfig runtimeConfig) {
-        if (runtimeConfig.enable()) {
+    public Consumer<Route> routeConsumer(Handler<RoutingContext> bodyHandler,
+            RuntimeValue<LoggingManagerRuntimeConfig> runtimeConfig) {
+        if (runtimeConfig.getValue().enable()) {
             return route -> route.handler(bodyHandler);
         } else {
             return route -> route.handler(new LoggingManagerNotFoundHandler());


### PR DESCRIPTION
To prevent this warning

```
Warning:  [io.quarkus.deployment] Run time configuration should not be consumed in Build Steps,
 use RuntimeValue<io.quarkiverse.loggingmanager.LoggingManagerRuntimeConfig> 
in a @Recorder constructor instead at io.quarkiverse.loggingmanager.LoggingManagerRuntimeConfig runtimeConfig of 
void io.quarkiverse.loggingmanager.deployment.LoggingManagerProcessor.includeRestEndpoints(io.quarkus.deployment.annotations.BuildProducer,io.quarkus.vertx.http.deployment.NonApplicationRootPathBuildItem,io.quarkiverse.loggingmanager.deployment.LoggingManagerConfig,io.quarkus.vertx.http.deployment.BodyHandlerBuildItem,io.quarkiverse.loggingmanager.LoggerManagerRecorder,io.quarkus.deployment.builditem.LaunchModeBuildItem,io.quarkiverse.loggingmanager.LoggingManagerRuntimeConfig) of class io.quarkiverse.loggingmanager.deployment.LoggingManagerProcessor
```