### PR TITLE
Add handler for new /duration endpoint to update logger level tempora…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@
 The **Quarkus Logging Manager** Extension provides you endpoints to visualize and manage the
 log level of your loggers.
 
-| Endpoint                                     | Http Method |                                             Description                                              |
-|----------------------------------------------|:-----------:|:----------------------------------------------------------------------------------------------------:|
-| `/q/logging-manager`                         |    `GET`    |      Returns the list of all loggers, with information about the configured and effective level      |
-| `/q/logging-manager?loggerName={loggerName}` |    `GET`    | Returns the logger specified by this name, with information about the configured and effective level |
-| `/q/logging-manager`                         |   `POST`    |                            Changes the log level of the specified logger                             |
-| `/q/logging-manager/levels`                  |    `GET`    |                                     Get all the available level                                      |
+| Endpoint                                     | Http Method |                                                                               Description                                                                               |
+|----------------------------------------------|:-----------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| `/q/logging-manager`                         |    `GET`    |                                       Returns the list of all loggers, with information about the configured and effective level                                        |
+| `/q/logging-manager?loggerName={loggerName}` |    `GET`    |                                  Returns the logger specified by this name, with information about the configured and effective level                                   |
+| `/q/logging-manager`                         |   `POST`    |                                                              Changes the log level of the specified logger                                                              |
+| `/q/logging-manager?temporary=true`          |   `POST`    |                         Temporarily changes the log level of the specified logger for a given duration, then restores it to the original level                          |
+| `/q/logging-manager/levels`                  |    `GET`    |                                                                             Get all the available level                                                                 |
 
 ## Security
 Security of endpoints is important, and we do not want to allow unknown people to know (or worse, change!) the log levels of

--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
@@ -53,7 +53,7 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
         openAPI.getPaths()
                 .addPathItem(basePath, createLoggersPathItem())
                 .addPathItem(basePath + "/levels", createLevelsPathItem())
-                .addPathItem(basePath + "/duration", createDurationPathItem());
+                .addPathItem(basePath + "/temporary-level", createTemporaryLevelPathItem());
     }
 
 
@@ -143,7 +143,7 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
                                                         .items(OASFactory.createSchema().ref(REF_LOGGER_LEVEL))))))));
     }
 
-    private PathItem createDurationPathItem() {
+    private PathItem createTemporaryLevelPathItem() {
         Map<String, Schema> properties = new LinkedHashMap<>();
         properties.put("loggerName", OASFactory.createSchema().type(List.of(Schema.SchemaType.STRING)));
         properties.put("loggerLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL));

--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
@@ -52,11 +52,8 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
         openAPI.addTag(tag);
         openAPI.getPaths()
                 .addPathItem(basePath, createLoggersPathItem())
-                .addPathItem(basePath + "/levels", createLevelsPathItem())
-                .addPathItem(basePath + "/temporary-level", createTemporaryLevelPathItem());
+                .addPathItem(basePath + "/levels", createLevelsPathItem());
     }
-
-
 
     private Schema createLoggerLevel() {
         Schema schema = OASFactory.createSchema()
@@ -109,10 +106,13 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
         Map<String, Schema> properties = new LinkedHashMap<>();
         properties.put("loggerName", OASFactory.createSchema().type(List.of(Schema.SchemaType.STRING)));
         properties.put("loggerLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL));
+        properties.put("duration", OASFactory.createSchema()
+                .type(List.of(Schema.SchemaType.INTEGER))
+                .description("Duration in seconds, used only if temporary=true"));
         return OASFactory.createOperation()
                 .operationId("logging_manager_update")
                 .summary("Update log level")
-                .description("Update a log level for a certain logger")
+                .description("Update a log level for a certain logger. Use query param `temporary=true` for temporary level.")
                 .tags(Collections.singletonList(tag))
                 .requestBody(OASFactory.createRequestBody()
                         .content(OASFactory.createContent().addMediaType(
@@ -121,7 +121,10 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
                                         .type(List.of(Schema.SchemaType.OBJECT))
                                         .properties(properties)))))
                 .responses(OASFactory.createAPIResponses()
-                        .addAPIResponse("201", OASFactory.createAPIResponse().description("Created")));
+                        .addAPIResponse("201", OASFactory.createAPIResponse().description("Created"))
+                        .addAPIResponse("200", OASFactory.createAPIResponse().description("Log level already set"))
+                        .addAPIResponse("400", OASFactory.createAPIResponse().description("Invalid request"))
+                        .addAPIResponse("404", OASFactory.createAPIResponse().description("Logger not found")));
     }
 
     private PathItem createLevelsPathItem() {
@@ -141,39 +144,6 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
                                                 OASFactory.createMediaType().schema(OASFactory.createSchema()
                                                         .type(List.of(Schema.SchemaType.ARRAY))
                                                         .items(OASFactory.createSchema().ref(REF_LOGGER_LEVEL))))))));
-    }
-
-    private PathItem createTemporaryLevelPathItem() {
-        Map<String, Schema> properties = new LinkedHashMap<>();
-        properties.put("loggerName", OASFactory.createSchema().type(List.of(Schema.SchemaType.STRING)));
-        properties.put("loggerLevel", OASFactory.createSchema().ref(REF_LOGGER_LEVEL));
-        properties.put("duration", OASFactory.createSchema()
-                                               .type(List.of(Schema.SchemaType.INTEGER))
-                                               .description("Duration in seconds before reverting to the previous level"));
-
-        return OASFactory.createPathItem()
-                 .summary("Set temporary log level duration")
-                 .description("Update a logger's level for a specified duration before reverting")
-                 .POST(OASFactory.createOperation()
-                          .operationId("logging_manager_set_duration")
-                          .summary("Set a temporary log level")
-                          .description("Set a log level for a specific logger that will automatically revert after a given duration")
-                          .tags(Collections.singletonList(tag))
-                          .requestBody(OASFactory.createRequestBody()
-                                  .content(OASFactory.createContent().addMediaType(
-                                            FORM_CONTENT_TYPE,
-                                            OASFactory.createMediaType().schema(OASFactory.createSchema()
-                                                    .type(List.of(Schema.SchemaType.OBJECT))
-                                                    .properties(properties)))))
-                          .responses(OASFactory.createAPIResponses()
-                                  .addAPIResponse("200", OASFactory.createAPIResponse()
-                                            .description("Log level already set to the requested value"))
-                                  .addAPIResponse("201", OASFactory.createAPIResponse()
-                                            .description("Temporary log level set successfully"))
-                                  .addAPIResponse("400", OASFactory.createAPIResponse()
-                                            .description("Invalid request: invalid level or duration"))
-                                  .addAPIResponse("404", OASFactory.createAPIResponse()
-                                            .description("Logger not found"))));
     }
 
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingmanager/LogController.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingmanager/LogController.java
@@ -107,6 +107,20 @@ public class LogController {
         return getEffectiveLogLevel(logger.getParent());
     }
 
+    public static boolean doesLoggerExist(String loggerName) {
+        LogContext logContext = LogContext.getLogContext();
+        Enumeration<String> loggerNames = logContext.getLoggerNames();
+
+        while (loggerNames.hasMoreElements()) {
+            String existingLoggerName = loggerNames.nextElement();
+            if (existingLoggerName.equals(loggerName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static final List<String> LEVELS = List.of(
             OFF.getName(),
             SEVERE.getName(),

--- a/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerHandler.java
@@ -4,8 +4,8 @@ import static io.vertx.core.http.HttpMethod.GET;
 import static io.vertx.core.http.HttpMethod.POST;
 
 import java.util.Objects;
-
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.jboss.logmanager.LogContext;
 
 import io.vertx.core.Handler;
@@ -22,9 +22,19 @@ public class LoggerHandler implements Handler<RoutingContext> {
     private static final String LOGGER_NAME_PARAM = "loggerName";
     private static final String LOGGER_LEVEL_PARAM = "loggerLevel";
     private static final String LOGGER_DURATION = "duration";
+    private static final String TEMPORARY_ENABLED = "temporary";
 
-    private final ConcurrentHashMap<String, Long> activeTimers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, TemporaryLogState> temporaryStates = new ConcurrentHashMap<>();
 
+    private static class TemporaryLogState {
+        final String originalLevel;
+        long timerId;
+
+        TemporaryLogState(String originalLevel, long timerId) {
+            this.originalLevel = originalLevel;
+            this.timerId = timerId;
+        }
+    }
 
     /**
      * Handles incoming HTTP requests by delegating to appropriate method handlers.
@@ -47,8 +57,8 @@ public class LoggerHandler implements Handler<RoutingContext> {
     }
 
     /**
-     * Handles GET requests to retrieve logger information.
-     * Returns all loggers if no logger name is specified, or details for a specific logger.
+     * Handles GET requests to retrieve logger information. Returns all loggers if no logger name is specified, or
+     * details for a specific logger.
      *
      * @param request The HTTP request
      * @param response The HTTP response
@@ -65,8 +75,8 @@ public class LoggerHandler implements Handler<RoutingContext> {
     }
 
     /**
-     * Handles POST requests to update logger levels.
-     * Updates the specified logger with the provided level or removes the level if none specified.
+     * Handles POST requests to update logger levels. Updates the specified logger with the provided level or removes
+     * the level if none specified.
      *
      * @param request The HTTP request
      * @param response The HTTP response
@@ -80,9 +90,11 @@ public class LoggerHandler implements Handler<RoutingContext> {
 
         String loggerName = request.getFormAttribute(LOGGER_NAME_PARAM);
         String loggerLevel = request.getFormAttribute(LOGGER_LEVEL_PARAM);
-        String loggerDuration = request.getFormAttribute(LOGGER_DURATION);
 
-        if (loggerDuration != null && !loggerDuration.isEmpty()) {
+        String temporaryEnabled = request.getParam(TEMPORARY_ENABLED);
+
+        if ("true".equalsIgnoreCase(temporaryEnabled)) {
+            String loggerDuration = request.getFormAttribute(LOGGER_DURATION);
             handleTemporaryPost(loggerName, loggerLevel, loggerDuration, routingContext, response);
             return;
         }
@@ -96,6 +108,16 @@ public class LoggerHandler implements Handler<RoutingContext> {
         response.setStatusCode(201).end();
     }
 
+    /**
+     * Handles POST requests to update logger levels temporarily. Updates the specified logger to the provided level
+     * for a given duration, then restores the original level automatically.
+     *
+     * @param loggerName The name of the logger to update
+     * @param loggerLevel The new temporary log level
+     * @param loggerDuration Duration in seconds for which the temporary level should apply
+     * @param routingContext The Vert.x routing context
+     * @param response The HTTP response
+     */
     private void handleTemporaryPost(
             String loggerName,
             String loggerLevel,
@@ -104,50 +126,49 @@ public class LoggerHandler implements Handler<RoutingContext> {
             HttpServerResponse response) {
 
         if (loggerLevel == null || !LogController.LEVELS.contains(loggerLevel.toUpperCase())) {
-            response.setStatusCode(400).end("Invalid Logger level");
+            response.setStatusCode(400).end("{\"error\":\"Invalid logger level\"}");
             return;
         }
 
         if (!LogController.doesLoggerExist(loggerName)) {
-            response.setStatusCode(404).end("Logger '" + loggerName + "' not found.");
+            response.setStatusCode(404).end("{\"error\":\"Logger '" + loggerName + "' not found\"}");
             return;
         }
 
         int durationSeconds;
-
         try {
             durationSeconds = Integer.parseInt(loggerDuration);
+            if (durationSeconds <= 0)
+                throw new NumberFormatException();
         } catch (NumberFormatException e) {
-            response.setStatusCode(400).end("Invalid duration");
+            response.setStatusCode(400).end("{\"error\":\"Duration must be a positive integer\"}");
             return;
         }
 
-        if (durationSeconds <= 0) {
-            response.setStatusCode(400).end("Duration must be positive");
+        String currentLevel = LogController.getConfiguredLogLevel(LogContext.getLogContext().getLogger(loggerName));
+        TemporaryLogState previousState = temporaryStates.get(loggerName);
+
+        if (loggerLevel.equalsIgnoreCase(currentLevel) && previousState == null) {
+            response.setStatusCode(200).end("{\"message\":\"Log level already set to " + loggerLevel + "\"}");
             return;
         }
 
-        String oldLevel = LogController.getConfiguredLogLevel(
-                LogContext.getLogContext().getLogger(loggerName));
-
-        if (oldLevel != null && oldLevel.equalsIgnoreCase(loggerLevel)) {
-            response.setStatusCode(200).end("Log level already set to " + loggerLevel);
-            return;
+        if (previousState != null) {
+            routingContext.vertx().cancelTimer(previousState.timerId);
         }
+
+        String originalLevel = previousState != null ? previousState.originalLevel : currentLevel;
 
         LogController.updateLogLevel(loggerName, loggerLevel);
 
-        Long previousTimerId = activeTimers.put(loggerName, null);
-        if (previousTimerId != null) {
-            routingContext.vertx().cancelTimer(previousTimerId);
-        }
-
         long timerId = routingContext.vertx().setTimer(durationSeconds * 1000L, id -> {
-            LogController.updateLogLevel(loggerName, oldLevel);
-            activeTimers.remove(loggerName, id);
+            LogController.updateLogLevel(loggerName, originalLevel);
+            temporaryStates.remove(loggerName);
         });
 
-        activeTimers.put(loggerName, timerId);
-        response.setStatusCode(201).end("Temporary log level set for " + durationSeconds + " seconds");
+        temporaryStates.put(loggerName, new TemporaryLogState(originalLevel, timerId));
+
+        response.setStatusCode(201)
+                .end("{\"message\":\"Temporary log level '" + loggerLevel + "' set for " + durationSeconds + " seconds\"}");
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerHandler.java
+++ b/runtime/src/main/java/io/quarkiverse/loggingmanager/LoggerHandler.java
@@ -5,6 +5,9 @@ import static io.vertx.core.http.HttpMethod.POST;
 
 import java.util.Objects;
 
+import java.util.concurrent.ConcurrentHashMap;
+import org.jboss.logmanager.LogContext;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -18,6 +21,10 @@ import io.vertx.ext.web.RoutingContext;
 public class LoggerHandler implements Handler<RoutingContext> {
     private static final String LOGGER_NAME_PARAM = "loggerName";
     private static final String LOGGER_LEVEL_PARAM = "loggerLevel";
+    private static final String LOGGER_DURATION = "duration";
+
+    private final ConcurrentHashMap<String, Long> activeTimers = new ConcurrentHashMap<>();
+
 
     /**
      * Handles incoming HTTP requests by delegating to appropriate method handlers.
@@ -33,7 +40,7 @@ public class LoggerHandler implements Handler<RoutingContext> {
         if (GET == method) {
             handleGet(request, response);
         } else if (POST == method) {
-            handlePost(request, response);
+            handlePost(request, response, routingContext);
         } else {
             response.setStatusCode(405).end(); // Method not allowed
         }
@@ -64,7 +71,7 @@ public class LoggerHandler implements Handler<RoutingContext> {
      * @param request The HTTP request
      * @param response The HTTP response
      */
-    private void handlePost(HttpServerRequest request, HttpServerResponse response) {
+    private void handlePost(HttpServerRequest request, HttpServerResponse response, RoutingContext routingContext) {
         String contentType = request.getHeader("Content-Type");
         if (!"application/x-www-form-urlencoded".equals(contentType)) {
             response.setStatusCode(415).end();
@@ -73,6 +80,12 @@ public class LoggerHandler implements Handler<RoutingContext> {
 
         String loggerName = request.getFormAttribute(LOGGER_NAME_PARAM);
         String loggerLevel = request.getFormAttribute(LOGGER_LEVEL_PARAM);
+        String loggerDuration = request.getFormAttribute(LOGGER_DURATION);
+
+        if (loggerDuration != null && !loggerDuration.isEmpty()) {
+            handleTemporaryPost(loggerName, loggerLevel, loggerDuration, routingContext, response);
+            return;
+        }
 
         if (loggerLevel == null || loggerLevel.isEmpty()) {
             LogController.updateLogLevel(loggerName, null);
@@ -81,5 +94,60 @@ public class LoggerHandler implements Handler<RoutingContext> {
         }
 
         response.setStatusCode(201).end();
+    }
+
+    private void handleTemporaryPost(
+            String loggerName,
+            String loggerLevel,
+            String loggerDuration,
+            RoutingContext routingContext,
+            HttpServerResponse response) {
+
+        if (loggerLevel == null || !LogController.LEVELS.contains(loggerLevel.toUpperCase())) {
+            response.setStatusCode(400).end("Invalid Logger level");
+            return;
+        }
+
+        if (!LogController.doesLoggerExist(loggerName)) {
+            response.setStatusCode(404).end("Logger '" + loggerName + "' not found.");
+            return;
+        }
+
+        int durationSeconds;
+
+        try {
+            durationSeconds = Integer.parseInt(loggerDuration);
+        } catch (NumberFormatException e) {
+            response.setStatusCode(400).end("Invalid duration");
+            return;
+        }
+
+        if (durationSeconds <= 0) {
+            response.setStatusCode(400).end("Duration must be positive");
+            return;
+        }
+
+        String oldLevel = LogController.getConfiguredLogLevel(
+                LogContext.getLogContext().getLogger(loggerName));
+
+        if (oldLevel != null && oldLevel.equalsIgnoreCase(loggerLevel)) {
+            response.setStatusCode(200).end("Log level already set to " + loggerLevel);
+            return;
+        }
+
+        LogController.updateLogLevel(loggerName, loggerLevel);
+
+        Long previousTimerId = activeTimers.put(loggerName, null);
+        if (previousTimerId != null) {
+            routingContext.vertx().cancelTimer(previousTimerId);
+        }
+
+        long timerId = routingContext.vertx().setTimer(durationSeconds * 1000L, id -> {
+            LogController.updateLogLevel(loggerName, oldLevel);
+            activeTimers.remove(loggerName, id);
+        });
+
+        activeTimers.put(loggerName, timerId);
+        response.setStatusCode(201).end("Temporary log level set for " + durationSeconds + " seconds");
     }
 }


### PR DESCRIPTION
## Pull Request Purpose

This PR introduces a new REST endpoint, `/q/logging-manager/duration`, that allows temporarily setting the log level of a specific logger for a defined duration. 

Sometimes, during debugging or troubleshooting, developers want to increase the log verbosity temporarily without manually resetting it afterward. With this new endpoint, after the specified duration expires, the logger’s level automatically reverts to its previous setting, avoiding unnecessary manual resets and reducing extra processing.

---

### `handleTemporaryPost`

Handles a POST request to temporarily update the log level of a specific logger for a given duration.

#### Parameters:
- `loggerName` (`String`): The name of the logger to update.
- `loggerLevel` (`String`): The new log level to set temporarily.
- `loggerDuration` (`String`): The duration (in seconds) for which the new log level should be active.
- `routingContext` (`RoutingContext`): Context of the current HTTP request.
- `response` (`HttpServerResponse`): HTTP response object used to send back status and messages.

#### Behavior:
1. Validates that `loggerLevel` is among the allowed log levels. Returns HTTP 400 if invalid.
2. Checks if the logger named `loggerName` exists. Returns HTTP 404 if not found.
3. Parses `loggerDuration` to an integer. Returns HTTP 400 if invalid or non-positive.
4. Retrieves the current configured log level for the logger.
5. If the current level is already equal to the requested level, returns HTTP 200 indicating no change needed.
6. Updates the logger’s level to the new temporary level.
7. Cancels any previously active timers set to revert the logger’s level.
8. Sets a new timer that will revert the logger’s level back to the previous one after the specified duration expires.
9. Stores the timer ID for future cancellation if needed.
10. Returns HTTP 201 indicating the temporary log level was successfully set.

#### Purpose:
Enables temporary adjustment of logger levels, useful for debugging or increased logging verbosity without manual reversion.
