### PR TITLE
fix: Add 'temporary' query param to logging API OpenAPI spec

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
+++ b/deployment/src/main/java/io/quarkiverse/loggingmanager/deployment/LoggingManagerOpenAPIFilter.java
@@ -114,6 +114,12 @@ public class LoggingManagerOpenAPIFilter implements OASFilter {
                 .summary("Update log level")
                 .description("Update a log level for a certain logger. Use query param `temporary=true` for temporary level.")
                 .tags(Collections.singletonList(tag))
+                .addParameter(OASFactory.createParameter()
+                        .name("temporary")
+                        .in(Parameter.In.QUERY)
+                        .description("Used to set the log level temporarily")
+                        .schema(OASFactory.createSchema().type(List.of(Schema.SchemaType.BOOLEAN)))
+                        .required(false))
                 .requestBody(OASFactory.createRequestBody()
                         .content(OASFactory.createContent().addMediaType(
                                 FORM_CONTENT_TYPE,


### PR DESCRIPTION
**What did I do?**

This pull request corrects the OpenAPI specification for the `POST /q/logging-manager` endpoint. It explicitly adds the `temporary` field as a query parameter.

**Why was this needed?**

Previously, I added the logging functionality, but the `temporary` parameter was only tested via `curl`. It was incorrectly defined in the OpenAPI specification, which meant that the Swagger UI and other tools generated from the spec were unaware of the parameter.

As a result, users of the Swagger UI could not easily test the "temporary" functionality.

This change ensures the specification reflects the endpoint's behavior correctly, aligns the documentation with the implementation, and improves the user experience for those using the Swagger UI.